### PR TITLE
Customize `generate:group`

### DIFF
--- a/src/Command/GenerateGroup.php
+++ b/src/Command/GenerateGroup.php
@@ -1,7 +1,7 @@
 <?php
 namespace Cake\Codeception\Command;
 
-use Codeception\Lib\Generator\Group as GroupGenerator;
+use Cake\Codeception\Lib\Generator\Group as GroupGenerator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Command/GenerateGroup.php
+++ b/src/Command/GenerateGroup.php
@@ -1,0 +1,40 @@
+<?php
+namespace Cake\Codeception\Command;
+
+use Codeception\Lib\Generator\Group as GroupGenerator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GenerateGroup extends \Codeception\Command\GenerateGroup
+{
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $config = $this->getGlobalConfig($input->getOption('config'));
+        $group = $input->getArgument('group');
+
+        $class = ucfirst($group);
+        $path = $this->buildPath($config['paths']['tests'] . '/Group/', $class);
+        $filename = $this->completeSuffix($class, 'Group');
+        $filename = $path . $filename;
+
+        $this->introduceAutoloader(
+            $config['paths']['tests'] . DIRECTORY_SEPARATOR . $config['settings']['bootstrap'],
+            'Group',
+            'Group'
+        );
+
+        $gen = new GroupGenerator($config, $group);
+        $res = $this->save($filename, $gen->produce());
+
+        if (!$res) {
+            $output->writeln("<error>Group $filename already exists</error>");
+            return;
+        }
+
+        $msg = [
+            "<info>Group extension was created in $filename</info>",
+            'To use this group extension, include it to "extensions" option of global Codeception config.'
+        ];
+        $output->writeln(implode("\n", $msg));
+    }
+}

--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -16,6 +16,7 @@ class Installer
         $needles = [
             'Build',
             'Bootstrap',
+            'GenerateGroup'
         ];
 
         foreach ($needles as $needle) {

--- a/src/Lib/Generator/Group.php
+++ b/src/Lib/Generator/Group.php
@@ -1,0 +1,37 @@
+<?php
+namespace Cake\Codeception\Lib\Generator;
+
+use Codeception\Util\Template;
+
+class Group extends \Codeception\Lib\Generator\Group
+{
+    protected $template = <<<EOF
+<?php
+namespace App\Test\Group;
+
+use Codeception\Event\TestEvent;
+use Codeception\Platform\Group;
+
+/**
+ * Group class is Codeception Extension which is allowed to handle to all internal events.
+ * This class itself can be used to listen events for test execution of one particular group.
+ * It may be especially useful to create fixtures data, prepare server, etc.
+ *
+ * INSTALLATION:
+ *
+ * To use this group extension, include it to "extensions" option of global Codeception config.
+ */
+class {{class}}Group extends Group
+{
+    public static \$group = '{{name}}';
+
+    public function _before(TestEvent \$e)
+    {
+    }
+
+    public function _after(TestEvent \$e)
+    {
+    }
+}
+EOF;
+}


### PR DESCRIPTION
In line with the rest of the cakephp/app directory structure, this PR renames the original `tests/_groups` folder to `tests/Group`. 
