### PR TITLE
Customize g:cest + template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,17 @@ php:
 
 before_install:
   - composer install
-  - composer require --prefer-dist --dev squizlabs/php_codesniffer:~2.0
-  - composer create-project --prefer-dist -s dev --no-interaction cakephp/app tests/test_app
+  - composer require --prefer-source --dev squizlabs/php_codesniffer:~2.0
+  - composer create-project --prefer-source -s dev --no-interaction cakephp/app tests/test_app
   - cp tests/Fixture/composer.json tests/test_app/.
   - cd tests/test_app
-  - composer require --prefer-dist --dev cakephp/codeception:dev-$TRAVIS_BRANCH#$TRAVIS_COMMIT
+  - composer require --prefer-source --dev cakephp/codeception:dev-$TRAVIS_BRANCH#$TRAVIS_COMMIT
   - vendor/bin/codecept bootstrap
   - vendor/bin/codecept generate:cest Functional Foo
   - vendor/bin/codecept generate:cept Functional Foo
   - cd ../sample_app
   - cp ../test_app/composer.json .
-  - composer install --prefer-dist
+  - composer install --prefer-source
   - vendor/bin/codecept build
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,17 @@ php:
 
 before_install:
   - composer install
-  - composer require --dev squizlabs/php_codesniffer:~2.0
+  - composer require --prefer-dist --dev squizlabs/php_codesniffer:~2.0
   - composer create-project --prefer-dist -s dev --no-interaction cakephp/app tests/test_app
   - cp tests/Fixture/composer.json tests/test_app/.
   - cd tests/test_app
-  - composer require --dev cakephp/codeception:dev-$TRAVIS_BRANCH#$TRAVIS_COMMIT
+  - composer require --prefer-dist --dev cakephp/codeception:dev-$TRAVIS_BRANCH#$TRAVIS_COMMIT
   - vendor/bin/codecept bootstrap
   - vendor/bin/codecept generate:cest Functional Foo
   - vendor/bin/codecept generate:cept Functional Foo
   - cd ../sample_app
   - cp ../test_app/composer.json .
-  - composer install
+  - composer install --prefer-dist
   - vendor/bin/codecept build
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,12 @@ before_install:
   - composer create-project --prefer-dist -s dev --no-interaction cakephp/app tests/test_app
   - cp tests/Fixture/composer.json tests/test_app/.
   - cd tests/test_app
-  - composer require --dev cakephp/codeception:dev-master
+  - composer require --dev cakephp/codeception:dev-$TRAVIS_BRANCH#$TRAVIS_COMMIT
   - vendor/bin/codecept bootstrap
   - vendor/bin/codecept generate:cest Functional Foo
   - vendor/bin/codecept generate:cept Functional Foo
   - cd ../sample_app
+  - cp ../test_app/composer.json .
   - composer install
   - vendor/bin/codecept build
 

--- a/src/Command/GenerateCest.php
+++ b/src/Command/GenerateCest.php
@@ -1,0 +1,35 @@
+<?php
+namespace Cake\Codeception\Command;
+
+use Cake\Codeception\Lib\Generator\Cest as CestGenerator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GenerateCest extends \Codeception\Command\GenerateCest
+{
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $suite = $input->getArgument('suite');
+        $class = $input->getArgument('class');
+
+        $config = $this->getSuiteConfig($suite, $input->getOption('config'));
+        $className = $this->getClassName($class);
+        $path = $this->buildPath($config['path'], $class);
+
+        $filename = $this->completeSuffix($className, 'Cest');
+        $filename = $path . $filename;
+
+        if (file_exists($filename)) {
+            $output->writeln("<error>Test $filename already exists</error>");
+            return;
+        }
+        $gen = new CestGenerator($class, $config);
+        $res = $this->save($filename, $gen->produce());
+        if (!$res) {
+            $output->writeln("<error>Test $filename already exists</error>");
+            return;
+        }
+
+        $output->writeln("<info>Test was created in $filename</info>");
+    }
+}

--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -22,6 +22,7 @@ class Installer
         $needles = [
             'Build',
             'Bootstrap',
+            'GenerateCest',
             'GenerateGroup'
         ];
 

--- a/src/Lib/Generator/Cest.php
+++ b/src/Lib/Generator/Cest.php
@@ -1,0 +1,28 @@
+<?php
+namespace Cake\Codeception\Lib\Generator;
+
+class Cest {
+
+    protected $template = <<<EOF
+<?php
+{{namespace}}
+
+class {{name}}Cest
+{
+    // @codingStandardsIgnoreStart
+    public function _before(UnitTester $I)// @codingStandardsIgnoreEnd
+    {
+    }
+
+    // @codingStandardsIgnoreStart
+    public function _after(UnitTester $I)// @codingStandardsIgnoreEnd
+    {
+    }
+
+    // tests
+    public function tryToTest({{actor}} \$I)
+    {
+    }
+}
+EOF;
+}

--- a/src/Lib/Generator/Cest.php
+++ b/src/Lib/Generator/Cest.php
@@ -1,21 +1,23 @@
 <?php
 namespace Cake\Codeception\Lib\Generator;
 
-class Cest {
+class Cest extends \Codeception\Lib\Generator\Cest
+{
 
     protected $template = <<<EOF
 <?php
 {{namespace}}
 
+
 class {{name}}Cest
 {
     // @codingStandardsIgnoreStart
-    public function _before(UnitTester $I)// @codingStandardsIgnoreEnd
+    public function _before({{actor}} \$I)// @codingStandardsIgnoreEnd
     {
     }
 
     // @codingStandardsIgnoreStart
-    public function _after(UnitTester $I)// @codingStandardsIgnoreEnd
+    public function _after({{actor}} \$I)// @codingStandardsIgnoreEnd
     {
     }
 

--- a/tests/TestCase/Command/GenerateCestTest.php
+++ b/tests/TestCase/Command/GenerateCestTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace Cake\Codeception\Test\TestCase\Command;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class GenerateCestTest extends TestCase
+{
+    public function testExecute()
+    {
+        $file = TEST_APP_ROOT . 'tests' . DS . 'Functional' . DS . 'FooCest.php';
+        $this->assertTrue(file_exists($file), "Cest file [$file] should be generated");
+    }
+
+    public function testGeneratorProduce()
+    {
+        $result = file_get_contents(TEST_APP_ROOT . 'tests' . DS . 'Functional' . DS . 'FooCest.php');
+
+        $expected = 'namespace App\Test\Functional;';
+        $this->assertContains($expected, $result, 'Namespace should be added');
+
+        $expected = "\n" .
+            '    // @codingStandardsIgnoreStart' . "\n" .
+            '    public function _before(FunctionalTester $I)// @codingStandardsIgnoreEnd';
+        $this->assertContains($expected, $result, 'Coding standards should be ignored');
+
+        $expected = "\n" .
+            '    // @codingStandardsIgnoreStart' . "\n" .
+            '    public function _after(FunctionalTester $I)// @codingStandardsIgnoreEnd';
+        $this->assertContains($expected, $result, 'Coding standards should be ignored');
+    }
+}


### PR DESCRIPTION
Another customization to make things look more like cake-land.

~~Tests will obviously fail because I haven't included `.travis.yml` yet on master (which this branch tracks).~~ Edit: I rebased from master and added tests.

More customizations will come but I think that's the last one before I can finish #1 and get it merged.

**Update:**
I also changed how dummy app tests are run. Previously, both dummy app (`test_app` and `sample_app`) would `composer require` the `dev-master` branch of this library. After ef51cf7 and 9bab0e3, they now use the branch that the PR is targeting (in this case `master`) and a commit that simulates the merge (in this case 4022052). This change allows to test the dummy apps using the same version of the library that the PR would be introducing.
