### PR TITLE
Edit the codecept file directly

### DIFF
--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -13,7 +13,8 @@ class Installer
      */
     public static function postAutoloadDump(Event $event)
     {
-        $binDir = dirname(dirname(dirname(dirname(__DIR__)))) . DIRECTORY_SEPARATOR . 'bin';
+        $binDir = dirname(dirname(dirname(dirname(__DIR__)))) . DIRECTORY_SEPARATOR;
+        $binDir = $binDir . 'codeception' . DIRECTORY_SEPARATOR . 'codeception';
         $binFile = $binDir . DIRECTORY_SEPARATOR . 'codecept';
         $contents = file_get_contents($binFile);
         $from = 'new Codeception\\Command\\';


### PR DESCRIPTION
Fixes #4 

The composer creates a symlink in the `vendor/bin` folder to the `codecept` file, but on the Windows it creates some proxy file which calls the `codecept`.

When updating the `vendor/bin/codecept` file on Linux it will edit the `vendor/bin/codeception/codeception/codecept` file. But on Windows it doesn't work because of the proxy file.

The direct editing of `vendor/bin/codeception/codeception/codecept` will solve the problem on the Windows and does exactly the same.
