### PR TITLE
Split helper

### DIFF
--- a/src/Command/Bootstrap.php
+++ b/src/Command/Bootstrap.php
@@ -170,6 +170,7 @@ class Bootstrap extends \Codeception\Command\Bootstrap
             'namespace' => 'App\Test\Unit',
             'modules' => [
                 'enabled' => [
+                    'Cake\Codeception\Framework',
                     'Asserts',
                     'App\TestSuite\Codeception\\' . $actor . 'Helper'
                 ]

--- a/src/Framework.php
+++ b/src/Framework.php
@@ -1,0 +1,134 @@
+<?php
+namespace Cake\Codeception;
+
+use Cake\Codeception\Helper\ConfigTrait;
+use Cake\Codeception\Helper\DbTrait;
+use Cake\Core\Configure;
+use Cake\Event\EventManager;
+use Cake\TestSuite\Fixture\FixtureManager;
+use Codeception\TestCase;
+
+class Framework extends \Codeception\Lib\Framework
+{
+
+    use ConfigTrait;
+    use DbTrait;
+
+    /**
+     * Module's default configuration.
+     *
+     * @var array
+     */
+    public $config = [
+        'autoFixtures' => true,
+        'dropTables' => false,
+    ];
+
+    /**
+     * The class responsible for managing the creation, loading and removing of fixtures
+     *
+     * @var \Cake\TestSuite\Fixture\FixtureManager
+     */
+    protected $fixtureManager = null;
+
+    /**
+     * Configure values to restore at end of test.
+     *
+     * @var array
+     */
+    protected $configure = [];
+
+    protected $testCase = null;
+
+    // @codingStandardsIgnoreStart
+    public function _before(TestCase $test) // @codingStandardsIgnoreEnd
+    {
+        if (method_exists($test, 'getTestClass')) {
+            $this->testCase = $test->getTestClass();
+        } else {
+            $this->testCase = $test;
+        }
+
+        if (!isset($this->testCase->autoFixtures)) {
+            $this->testCase->autoFixtures = $this->config['autoFixtures'];
+        }
+
+        if (!isset($this->testCase->dropTables)) {
+            $this->testCase->dropTables = $this->config['dropTables'];
+        }
+
+        EventManager::instance(new EventManager());
+        $this->fixtureManager = new FixtureManager();
+
+        if ($this->testCase->autoFixtures) {
+            if (!isset($this->testCase->fixtures)) {
+                $this->testCase->fixtures = [];
+            }
+            $this->loadFixtures($this->testCase->fixtures);
+        }
+
+        $this->snapshotApplication();
+    }
+
+    // @codingStandardsIgnoreStart
+    public function _after(TestCase $test) // @codingStandardsIgnoreEnd
+    {
+        $this->resetApplication();
+        $this->fixtureManager->unload($this->testCase);
+        if ($this->testCase->dropTables) {
+            $this->fixtureManager->shutDown();
+        }
+    }
+
+    /**
+     * Chooses which fixtures to load for a given test
+     *
+     * @return void
+     */
+    public function loadFixtures($fixtures)
+    {
+        if (func_num_args() > 1) {
+            $fixtures = func_get_args();
+        }
+        $this->testCase->fixtures = $fixtures;
+        $this->fixtureManager->fixturize($this->testCase);
+        $this->fixtureManager->load($this->testCase);
+    }
+
+    /**
+     * Asserts the expected CakePHP version.
+     *
+     * @param string $ver Expected version.
+     * @param string $operator Comparison to run, defaults to greater or equal.
+     * @
+     */
+    public function expectedCakePHPVersion($ver, $operator = 'ge')
+    {
+        $this->assertTrue(version_compare($ver, Configure::version(), $operator));
+    }
+
+    /**
+     * Resets the application's configuration.
+     *
+     * @return void
+     */
+    protected function resetApplication()
+    {
+        if (!empty($this->configure)) {
+            Configure::clear();
+            Configure::write($this->configure);
+        }
+    }
+
+    /**
+     * Snapshots the application's configuration.
+     *
+     * @return void
+     */
+    protected function snapshotApplication()
+    {
+        if (empty($this->configure)) {
+            $this->configure = Configure::read();
+        }
+    }
+}

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -2,119 +2,28 @@
 namespace Cake\Codeception;
 
 use Cake\Codeception\Helper\AuthTrait;
-use Cake\Codeception\Helper\ConfigTrait;
-use Cake\Codeception\Helper\DbTrait;
 use Cake\Codeception\Helper\DispatcherTrait;
 use Cake\Codeception\Helper\RouterTrait;
 use Cake\Codeception\Helper\SessionTrait;
 use Cake\Codeception\Helper\ViewTrait;
-use Cake\Core\Configure;
-use Cake\Event\EventManager;
 use Cake\Routing\Router;
-use Cake\TestSuite\Fixture\FixtureManager;
-use Codeception\Lib\Framework;
 use Codeception\TestCase;
 
 class Helper extends Framework
 {
 
     use AuthTrait;
-    use ConfigTrait;
-    use DbTrait;
     use DispatcherTrait;
     use RouterTrait;
     use SessionTrait;
     use ViewTrait;
 
-    /**
-     * Module's default configuration.
-     *
-     * @var array
-     */
-    public $config = [
-        'autoFixtures' => true,
-        'dropTables' => false,
-    ];
-
-    /**
-     * The class responsible for managing the creation, loading and removing of fixtures
-     *
-     * @var \Cake\TestSuite\Fixture\FixtureManager
-     */
-    protected $fixtureManager = null;
-
-    /**
-     * Configure values to restore at end of test.
-     *
-     * @var array
-     */
-    protected $configure = [];
-
-    protected $testCase = null;
-
-// @codingStandardsIgnoreStart
-    public function _before(TestCase $test)
+    // @codingStandardsIgnoreStart
+    public function _before(TestCase $test) // @codingStandardsIgnoreEnd
     {
-        if (method_exists($test, 'getTestClass')) {
-            $this->testCase = $test->getTestClass();
-        } else {
-            $this->testCase = $test;
-        }
-
-        if (!isset($this->testCase->autoFixtures)) {
-            $this->testCase->autoFixtures = $this->config['autoFixtures'];
-        }
-
-        if (!isset($this->testCase->dropTables)) {
-            $this->testCase->dropTables = $this->config['dropTables'];
-        }
-
-        EventManager::instance(new EventManager());
-        $this->fixtureManager = new FixtureManager();
-
-        if ($this->testCase->autoFixtures) {
-            if (!isset($this->testCase->fixtures)) {
-                $this->testCase->fixtures = [];
-            }
-            $this->loadFixtures($this->testCase->fixtures);
-        }
-
+        parent::_before($test);
         $this->client = $this->getConnectorInstance();
-
-        $this->snapshotApplication();
         $this->reloadRoutes();
-    }
-
-    public function _after(TestCase $test)
-    {
-        $this->resetApplication();
-        $this->fixtureManager->unload($this->testCase);
-        if ($this->testCase->dropTables) {
-            $this->fixtureManager->shutDown();
-        }
-    }
-// @codingStandardsIgnoreEnd
-
-    public function loadFixtures($fixtures)
-    {
-        if (func_num_args() > 1) {
-            $fixtures = func_get_args();
-        }
-        $this->testCase->fixtures = $fixtures;
-        $this->fixtureManager->fixturize($this->testCase);
-        $this->fixtureManager->load($this->testCase);
-    }
-
-    /**
-     * Asserts the expected CakePHP version.
-     *
-     * @param string $ver Expected version.
-     * @param string $operator Comparison to run, defaults to greater or equal.
-     * @
-     */
-    public function expectedCakePHPVersion($ver, $operator = 'ge')
-    {
-        $this->assertTrue(version_compare($ver, Configure::version(), $operator));
     }
 
     /**
@@ -137,31 +46,6 @@ class Helper extends Framework
     protected function reloadRoutes()
     {
         Router::reload();
-    }
-
-    /**
-     * Resets the application's configuration.
-     *
-     * @return void
-     */
-    protected function resetApplication()
-    {
-        if (!empty($this->configure)) {
-            Configure::clear();
-            Configure::write($this->configure);
-        }
-    }
-
-    /**
-     * Snapshots the application's configuration.
-     *
-     * @return void
-     */
-    protected function snapshotApplication()
-    {
-        if (empty($this->configure)) {
-            $this->configure = Configure::read();
-        }
     }
 
     /**


### PR DESCRIPTION
Some tests (i.e. unit) do not require a full integration, just access to some basics like `loadFixtures()`, the configuration, db, etc.
