### PR TITLE
Add `cleanUpInsertedRecords` option/method

### DIFF
--- a/src/Framework.php
+++ b/src/Framework.php
@@ -22,6 +22,7 @@ class Framework extends \Codeception\Lib\Framework
     public $config = [
         'autoFixtures' => true,
         'dropTables' => false,
+        'cleanUpInsertedRecords' => true,
     ];
 
     /**
@@ -57,6 +58,10 @@ class Framework extends \Codeception\Lib\Framework
             $this->testCase->dropTables = $this->config['dropTables'];
         }
 
+        if (!isset($this->testCase->cleanUpInsertedRecords)) {
+            $this->testCase->cleanUpInsertedRecords = $this->config['cleanUpInsertedRecords'];
+        }
+
         EventManager::instance(new EventManager());
         $this->fixtureManager = new FixtureManager();
 
@@ -74,6 +79,11 @@ class Framework extends \Codeception\Lib\Framework
     public function _after(TestCase $test) // @codingStandardsIgnoreEnd
     {
         $this->resetApplication();
+
+        if ($this->testCase->cleanUpInsertedRecords) {
+            $this->cleanUpInsertedRecords();
+        }
+
         $this->fixtureManager->unload($this->testCase);
         if ($this->testCase->dropTables) {
             $this->fixtureManager->shutDown();

--- a/src/Helper/DbTrait.php
+++ b/src/Helper/DbTrait.php
@@ -5,6 +5,36 @@ use Cake\ORM\TableRegistry;
 
 trait DbTrait
 {
+    protected $insertedRecords = [];
+
+    /**
+     * Cleans up inserted records.
+     *
+     * @param string $model Model alias.
+     * @param array $conditions Conditions passed to `Cake\ORM\Table::deleteAll()`.
+     * @return void
+     */
+    public function cleanUpInsertedRecords($model = null, array $conditions = [])
+    {
+        $records = $this->insertedRecords;
+
+        if (empty($records)) {
+            return;
+        }
+
+        if (!empty($model) && !empty($records[$model])) {
+            if (!empty($data)) {
+                TableRegistry::get($model)->deleteAll($data);
+                return;
+            }
+
+            $records = [$model => $records[$model]];
+        }
+
+        foreach ($records as $model => $data) {
+            TableRegistry::get($model)->deleteAll($data);
+        }
+    }
 
     /**
      * Inserts record into the database.
@@ -25,6 +55,11 @@ trait DbTrait
             $this->fail('Could not insert record into table ' . $model);
         }
 
+        if (empty($this->insertedRecords[$model])) {
+            $this->insertedRecords[$model] = [];
+        }
+
+        $this->insertedRecords[$model][] = $data->toArray();
         return $data->{$table->primaryKey()};
     }
 


### PR DESCRIPTION
When inserting records per test using `$I->haveRecord()`, added
data is now automatically cleaned up (unless the config option
`cleanUpInsertedRecords` is set to `FALSE`).
