### PR TITLE
Add ORM related helper methods

### DIFF
--- a/src/Framework.php
+++ b/src/Framework.php
@@ -3,6 +3,7 @@ namespace Cake\Codeception;
 
 use Cake\Codeception\Helper\ConfigTrait;
 use Cake\Codeception\Helper\DbTrait;
+use Cake\Codeception\Helper\ORMTrait;
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
 use Cake\TestSuite\Fixture\FixtureManager;
@@ -13,6 +14,7 @@ class Framework extends \Codeception\Lib\Framework
 
     use ConfigTrait;
     use DbTrait;
+    use ORMTrait;
 
     /**
      * Module's default configuration.

--- a/src/Helper/ORMTrait.php
+++ b/src/Helper/ORMTrait.php
@@ -5,6 +5,59 @@ use Cake\ORM\TableRegistry;
 
 trait ORMTrait
 {
+
+    public function seeAssociation($table, $name, $type = null, array $options = [])
+    {
+        if (!($table instanceof Table)) {
+            $table = $this->grabTable($table);
+        }
+
+        $association = $table->association($name);
+
+        if (empty($options) && empty($type)) {
+            $this->assertNotEmpty($association);
+            return;
+        }
+
+        if (!empty($type)) {
+            $this->assertEquals($type, $association->type());
+        }
+
+        foreach ($options as $key => $value) {
+            $this->assertEquals($association->{$key}(), $value);
+        }
+    }
+
+    public function dontSeeAssociation($table, $name, $type = null, array $options = [])
+    {
+        if (!($table instanceof Table)) {
+            $table = $this->grabTable($table);
+        }
+
+        $association = $table->association($name);
+
+        if (empty($options) && empty($type)) {
+            $this->assertEmpty($association);
+            return;
+        }
+
+        if (empty($options) && !empty($type)) {
+            $this->assertNotEquals($type, $association->type());
+            return;
+        }
+
+        foreach ($options as $key => $value) {
+            if ($association->{$key}() !== $value) {
+                $this->assertTrue(true);
+                return;
+            }
+
+        }
+
+        $this->assertNotEquals($type, $association->type());
+        $this->assertNotEquals($options, $options);
+    }
+
     public function seeValidationErrors($entity, $data, array $expectedErrors = [])
     {
         $errors = $this->tryValidating($entity, $data);

--- a/src/Helper/ORMTrait.php
+++ b/src/Helper/ORMTrait.php
@@ -1,0 +1,69 @@
+<?php
+namespace Cake\Codeception\Helper;
+
+use Cake\ORM\TableRegistry;
+
+trait ORMTrait
+{
+    public function seeValidationErrors($entity, $data, array $expectedErrors = [])
+    {
+        $errors = $this->tryValidating($entity, $data);
+
+        foreach ($expectedErrors as $field => $error) {
+            if (is_numeric($field)) {
+                $field = $error;
+                $error = null;
+            }
+
+            $this->assertContains($field, array_keys($errors), json_encode($errors));
+
+            if (empty($error)) {
+                continue;
+            }
+
+            $error = (array)$error;
+
+            foreach ($error as $name => $message) {
+                if (is_numeric($name)) {
+                    $name = $message;
+                    $message = null;
+                }
+
+                $this->assertContains($name, array_keys($errors[$field]));
+                if (empty($message)) {
+                    continue;
+                }
+
+                $this->assertEquals($message, $errors[$field][$name]);
+            }
+        }
+    }
+
+    public function dontSeeValidationErrors($entity, $data)
+    {
+        $errors = $this->tryValidating($entity, $data);
+        $this->assertEquals(0, count($errors), json_encode($errors));
+    }
+
+    public function grabTable($alias)
+    {
+        return TableRegistry::get($alias);
+    }
+
+    public function tryPatching($entity, $data)
+    {
+        if (!($entity instanceof Entity)) {
+            $table = $this->grabTable($entity);
+            $entity = $table->newEntity();
+        } else {
+            $table = $this->grabTable($entity->source());
+        }
+
+        return $table->patchEntity($entity, $data);
+    }
+
+    public function tryValidating($entity, $data)
+    {
+        return $this->tryPatching($entity, $data)->errors();
+    }
+}


### PR DESCRIPTION
This adds helper methods to the `Cake\Codeception\Framework` module making it simple to interact with the `Cake\ORM`. 
#### TODO
- [x] `ORMTrait::grabTable()`
- [x] `ORMTrait::tryPatching()`
- [x] `ORMTrait::tryValidating()`
- [x] `ORMTrait::seeValidationErrors()`
- [x] `ORMTrait::dontSeeValidationErrors()`
- [x] `ORMTrait::seeAssociation()`
- [x] `ORMTrait::dontSeeAssociation()`

Needless to say, there are more that could be added but those should cover the basics for now.
