### PR TITLE
Handle errors using the same method as IntegrationTestCase

### DIFF
--- a/src/Command/GenerateSuite.php
+++ b/src/Command/GenerateSuite.php
@@ -8,7 +8,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 
-
 /**
  * Create new test suite. Requires suite name and actor name
  *
@@ -28,7 +27,7 @@ class GenerateSuite extends \Codeception\Command\GenerateSuite
         $suite = ucfirst($input->getArgument('suite'));
         $actor = $input->getArgument('actor');
 
-        if ($this->containsInvalidCharacters ($suite)) {
+        if ($this->containsInvalidCharacters($suite)) {
             $output->writeln("<error>Suite name '$suite' contains invalid characters. ([A-Za-z0-9_]).</error>");
             return;
         }
@@ -47,7 +46,8 @@ class GenerateSuite extends \Codeception\Command\GenerateSuite
         $this->buildPath($dir . $suite . DIRECTORY_SEPARATOR, 'bootstrap.php');
 
         // generate bootstrap
-        $this->save($dir . $suite . DIRECTORY_SEPARATOR . 'bootstrap.php',
+        $this->save(
+            $dir . $suite . DIRECTORY_SEPARATOR . 'bootstrap.php',
             "<?php\n// Here you can initialize variables that will be available to your tests\n",
             true
         );
@@ -80,8 +80,8 @@ class GenerateSuite extends \Codeception\Command\GenerateSuite
         $output->writeln("<info>Suite $suite generated</info>");
     }
 
-    private function containsInvalidCharacters ($suite)
+    private function containsInvalidCharacters($suite)
     {
-        return preg_match ('#[^A-Za-z0-9_]#', $suite) ? true : false;
+        return preg_match('#[^A-Za-z0-9_]#', $suite) ? true : false;
     }
 }

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -126,11 +126,33 @@ class Connector extends Client
 
         try {
             $dispatcher->dispatch($request, $response);
-        } catch (\Exception $e) {
+        } catch (\PHPUnit_Exception $e) {
             throw $e;
+        } catch (\Exception $e) {
+            $response = $this->_handleError($e);
         }
 
         return $response;
+    }
+
+    /**
+     * Attempts to render an error response for a given exception.
+     *
+     * This method will attempt to use the configured exception renderer.
+     * If that class does not exist, the built-in renderer will be used.
+     *
+     * @param \Exception $exception Exception to handle.
+     * @return void
+     * @throws \Exception
+     */
+    protected function _handleError($exception)
+    {
+        $class = Configure::read('Error.exceptionRenderer');
+        if (empty($class) || !class_exists($class)) {
+            $class = 'Cake\Error\ExceptionRenderer';
+        }
+        $instance = new $class($exception);
+        return $instance->render();
     }
 
     /**

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -129,7 +129,7 @@ class Connector extends Client
         } catch (\PHPUnit_Exception $e) {
             throw $e;
         } catch (\Exception $e) {
-            $response = $this->_handleError($e);
+            $response = $this->handleError($e);
         }
 
         return $response;
@@ -145,7 +145,7 @@ class Connector extends Client
      * @return void
      * @throws \Exception
      */
-    protected function _handleError($exception)
+    protected function handleError($exception)
     {
         $class = Configure::read('Error.exceptionRenderer');
         if (empty($class) || !class_exists($class)) {


### PR DESCRIPTION
This allows developers to override the ExceptionRenderer in their Api tests for the purposes of testing the actual response.

Note that bootstrap.php will _delete_ the `Error` key due to it's use of `Configure::consume()` when configuring an error handler, and as such it is up to the developer to specify a custom Exception Renderer.

One other thing: Headers will not be set for the response, just as they are not in IntegrationTestCase
