### PR TITLE
Call Response->sendHeaders() before returning a BrowserKitResponse object

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -100,6 +100,7 @@ class Connector extends Client
             ));
         }
 
+        $response->sendHeaders();
         return new BrowserKitResponse(
             $response->body(),
             $response->statusCode(),


### PR DESCRIPTION
This will allow the content type header to be properly set.

Note: `setcookie` and `header` will be called, though these will be noops in a testing context.
