### PR TITLE
Fixes DbTrait::cleanUpInsertedRecords

### DIFF
--- a/src/Helper/DbTrait.php
+++ b/src/Helper/DbTrait.php
@@ -11,10 +11,9 @@ trait DbTrait
      * Cleans up inserted records.
      *
      * @param string $model Model alias.
-     * @param array $conditions Conditions passed to `Cake\ORM\Table::deleteAll()`.
      * @return void
      */
-    public function cleanUpInsertedRecords($model = null, array $conditions = [])
+    public function cleanUpInsertedRecords($model = null)
     {
         $records = $this->insertedRecords;
 
@@ -23,12 +22,8 @@ trait DbTrait
         }
 
         if (!empty($model) && !empty($records[$model])) {
-            if (!empty($data)) {
-                TableRegistry::get($model)->deleteAll($data);
-                return;
-            }
-
-            $records = [$model => $records[$model]];
+            TableRegistry::get($model)->deleteAll($records[$model]);
+            return;
         }
 
         foreach ($records as $model => $data) {

--- a/src/Helper/DbTrait.php
+++ b/src/Helper/DbTrait.php
@@ -59,7 +59,7 @@ trait DbTrait
             $this->insertedRecords[$model] = [];
         }
 
-        $this->insertedRecords[$model][] = $data->toArray();
+        $this->insertedRecords[$model][$table->primaryKey()][] = $data->{$table->primaryKey()};
         return $data->{$table->primaryKey()};
     }
 


### PR DESCRIPTION
DbTrait::cleanUpInsertedRecords() don't work correctly.

I think better to delete conditions using the primary key.
and, I think that there is no need `$conditions` option for this method.
