### PR TITLE
fixes the delete condition in DbTrait::cleanUpInsertedRecords

### DIFF
--- a/src/Helper/DbTrait.php
+++ b/src/Helper/DbTrait.php
@@ -54,7 +54,7 @@ trait DbTrait
             $this->insertedRecords[$model] = [];
         }
 
-        $this->insertedRecords[$model][$table->primaryKey()][] = $data->{$table->primaryKey()};
+        $this->insertedRecords[$model][$table->primaryKey() . ' IN'][] = $data->{$table->primaryKey()};
         return $data->{$table->primaryKey()};
     }
 


### PR DESCRIPTION
DbTrait::cleanUpInsertedRecords can't delete the inserted records, correctly.

CakePHP 3's query builder does not expand the `IN` clause automatically, when the value in a conditional statement is an array.
The conditions need to explicitly specify the `IN` clause.

It's my mistake.
