### PR TITLE
Update codeception to 2.1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "codeception/codeception": "2.0.*"
+        "codeception/codeception": "2.1.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
When running codeception I've got error:

```
PHP Fatal error:  Class 'Symfony\Component\CssSelector\CssSelector' not found
```

This might be due to outdated dependency to old codeception. Could it be updated?
