### PR TITLE
fixes loadFixtures with empty arguments

### DIFF
--- a/src/Helper/FixtureTrait.php
+++ b/src/Helper/FixtureTrait.php
@@ -114,7 +114,7 @@ trait FixtureTrait
         if (empty($args)) {
             $autoFixtures = $this->testCase->autoFixtures;
             $this->testCase->autoFixtures = true;
-            $this->fixtureManager->load($this);
+            $this->fixtureManager->load($this->testCase);
             $this->testCase->autoFixtures = $autoFixtures;
         }
     }

--- a/tests/sample_app/tests/Functional/FixtureLoadCest.php
+++ b/tests/sample_app/tests/Functional/FixtureLoadCest.php
@@ -12,7 +12,8 @@ class FixtureLoadCest
 
     public $autoFixtures = false;
     public $fixtures = [
-        'core.Authors',
+        'core.authors',
+        'core.posts',
     ];
 
     /**
@@ -20,9 +21,12 @@ class FixtureLoadCest
      */
     public function tryLoadFixtures(FunctionalTester $I)
     {
-        $I->wantTo('loading the Authors fixture');
+        $I->wantTo('loading fixtures manulary');
         $I->loadFixtures('Authors');
         $I->seeInDatabase('authors', ['id' => 1, 'name' => 'mariano']);
+
+        $I->loadFixtures();
+        $I->seeInDatabase('posts', ['author_id' => 1, 'title' => 'First Post']);
     }
 
 }


### PR DESCRIPTION
By my modification, calling loadFixtures with no arguments don't work correctly. 
Fixes it.