### PR TITLE
Drop constraints on cleanup inserted records

### DIFF
--- a/src/Helper/DbTrait.php
+++ b/src/Helper/DbTrait.php
@@ -22,13 +22,30 @@ trait DbTrait
         }
 
         if (!empty($model) && !empty($records[$model])) {
-            TableRegistry::get($model)->deleteAll($records[$model]);
+            $this->deleteAllRecords($model, $records[$model]);
+
             return;
         }
 
         foreach ($records as $model => $data) {
-            TableRegistry::get($model)->deleteAll($data);
+            $this->deleteAllRecords($model, $data);
         }
+    }
+
+    /**
+     * Delete inserted records with constraints disabled.
+     *
+     * @param string $model Model alias.
+     * @param array $data Delete target conditions.
+     * @return void
+     */
+    protected function deleteAllRecords($model, $data)
+    {
+        $table = TableRegistry::get($model);
+        $table->connection()
+            ->disableConstraints(function () use ($table, $data) {
+                $table->deleteAll($data);
+            });
     }
 
     /**

--- a/tests/sample_app/tests/Fixture/ProjectsFixture.php
+++ b/tests/sample_app/tests/Fixture/ProjectsFixture.php
@@ -1,0 +1,47 @@
+<?php
+namespace App\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * ProjectsFixture
+ *
+ */
+class ProjectsFixture extends TestFixture
+{
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+        'created_at' => ['type' => 'timestamp', 'length' => null, 'null' => false, 'default' => 'CURRENT_TIMESTAMP', 'comment' => '', 'precision' => null],
+        'updated_at' => ['type' => 'timestamp', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'name' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => 1,
+            'created_at' => 1519886874,
+            'updated_at' => 1519886874,
+            'name' => 'First Project'
+        ],
+    ];
+}

--- a/tests/sample_app/tests/Fixture/TasksFixture.php
+++ b/tests/sample_app/tests/Fixture/TasksFixture.php
@@ -1,0 +1,55 @@
+<?php
+namespace App\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * TasksFixture
+ *
+ */
+class TasksFixture extends TestFixture
+{
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+        'created_at' => ['type' => 'timestamp', 'length' => null, 'null' => false, 'default' => 'CURRENT_TIMESTAMP', 'comment' => '', 'precision' => null],
+        'updated_at' => ['type' => 'timestamp', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'project_id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'title' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        'due_date' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        '_indexes' => [
+            'FK_tasks_project_id_idx' => ['type' => 'index', 'columns' => ['project_id'], 'length' => []],
+        ],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+            'FK_tasks_project_id' => ['type' => 'foreign', 'columns' => ['project_id'], 'references' => ['projects', 'id'], 'update' => 'noAction', 'delete' => 'noAction', 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => 1,
+            'created_at' => 1519886880,
+            'updated_at' => 1519886880,
+            'project_id' => 1,
+            'title' => 'First task',
+            'due_date' => '2018-03-01 06:48:00'
+        ],
+    ];
+}

--- a/tests/sample_app/tests/Unit/Helper/DbHelperCest.php
+++ b/tests/sample_app/tests/Unit/Helper/DbHelperCest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Test\Unit\Helper;
+
+use App\TestSuite\Codeception\UnitTester;
+
+/**
+ * Test for CakeFixture module, auto load fixtures.
+ */
+class DbHelperCest
+{
+
+    public $fixtures = [
+        'app.Projects',
+        'app.Tasks',
+    ];
+
+    /**
+     * @param UnitTester $I
+     */
+    public function testCleanUpInsertedRecordsWithForeignKey(UnitTester $I)
+    {
+        $I->wantTo('append and cleanup records');
+
+        // Tasks depends Projects
+        $projectId = $I->haveRecord('Projects', ['name' => 'Awesome Project']);
+        $I->haveRecord('Tasks', ['title' => 'Awesome Task', 'project_id' => $projectId]);
+
+        // Cleanup Projects before Tasks, it will be throw exception if can't drop constraints.
+        $I->cleanUpInsertedRecords('Projects');
+        $I->cleanUpInsertedRecords('Tasks');
+    }
+}


### PR DESCRIPTION
I running `cleanUpInsertedRecords()` on a table that has a foreign key constraint, the constraint will cause the deletion to fail.

With this fix, canceling the constraint at the time of deletion,  and can delete it.