### PR TITLE
Fixture in Cept

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ $I->dontSeeRecord('users', ['email' => 'jadb@cakephp.org']);
 
 ### Miscellaneous
 
-#### Load fixtures (Only Cest)
+#### Load fixtures
 
 In your `Cest` test case, write `$fixutures` property:
 
@@ -185,8 +185,8 @@ In your `Cest` test case, write `$fixutures` property:
 class AwesomeCest
 {
     public $fixtures = [
-        'app.Users',
-        'app.Posts',
+        'app.users',
+        'app.posts',
     ];
 
     // ...
@@ -201,17 +201,32 @@ class AwesomeCest
     public $autoFixtures = false;
     public $dropTables = false;
     public $fixtures = [
-        'app.Users',
-        'app.Posts',
+        'app.users',
+        'app.posts',
     ];
 
     public function tryYourSenario($I)
     {
         // load fixtures manually
-        $I->loadFixtures('Users');
+        $I->loadFixtures('Users', 'Posts');
+        // or load all fixtures
+        $I->loadFixtures();
         // ...
     }
 }
+```
+
+In your `Cept` test case, use `$I->useFixtures()` and `$I->loadFixtures()`:
+
+```php
+$I = new FunctionalTester($scenario);
+
+// You should call `useFixtures` before `loadFixtures`
+$I->useFixtures('app.users', 'app.posts');
+// Then load fixtures manually
+$I->loadFixtures('Users', 'Posts');
+// or load all fixtures
+$I->loadFixtures();
 ```
 
 #### Assert CakePHP version with `expectedCakePHPVersion($ver, $operator = 'ge')`

--- a/tests/sample_app/tests/Functional.suite.yml
+++ b/tests/sample_app/tests/Functional.suite.yml
@@ -13,4 +13,5 @@ modules:
         # add a framework module here
         - \Cake\Codeception\Helper
         - Db
+        - Asserts
         - \App\TestSuite\Codeception\Helper\Functional

--- a/tests/sample_app/tests/Functional/LoadFixturesCept.php
+++ b/tests/sample_app/tests/Functional/LoadFixturesCept.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\TestSuite\Codeception\FunctionalTester;
+
+$I = new FunctionalTester($scenario);
+
+$I->wantTo('load fixtures');
+
+$I->useFixtures(['core.authors', 'core.posts']);
+$I->loadFixtures('Authors');
+$I->seeInDatabase('authors', ['id' => 1, 'name' => 'mariano']);
+
+$I->loadFixtures();
+$I->seeInDatabase('posts', ['author_id' => 1, 'title' => 'First Post']);
+
+// useFixtures use only once
+$I->expectException('\Codeception\Exception\ModuleException', function () use ($I) {
+    $I->useFixtures('core.tags');
+});

--- a/tests/sample_app/tests/Functional/LoadFixturesCest.php
+++ b/tests/sample_app/tests/Functional/LoadFixturesCest.php
@@ -5,9 +5,9 @@ namespace App\Test\Functional;
 use App\TestSuite\Codeception\FunctionalTester;
 
 /**
- * Test for loadFixtures()
+ * Test for CakeFixture::loadFixtures()
  */
-class FixtureLoadCest
+class LoadFixturesCest
 {
 
     public $autoFixtures = false;
@@ -27,6 +27,10 @@ class FixtureLoadCest
 
         $I->loadFixtures();
         $I->seeInDatabase('posts', ['author_id' => 1, 'title' => 'First Post']);
-    }
 
+        // useFixtures use only once
+        $I->expectException('\Codeception\Exception\ModuleException', function () use ($I) {
+            $I->useFixtures('core.tags');
+        });
+    }
 }


### PR DESCRIPTION
Support load fixtures in Cept test case.


```php
$I = new FunctionalTester($scenario);

// You should call `useFixtures` before `loadFixtures`
$I->useFixtures('app.users', 'app.posts');
// Then load fixtures manually
$I->loadFixtures('Users', 'Posts');
// or load all fixtures
$I->loadFixtures();
```
