### PR TITLE
Fix json request

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -63,9 +63,11 @@ class Connector extends Client
 
         $_ENV = $environment = ['REQUEST_METHOD' => $request->getMethod()] + $request->getServer();
 
+        $content = (array_key_exists('CONTENT_TYPE', $environment) && $environment['CONTENT_TYPE'] == 'application/json') ? json_decode($request->getContent(), true) : (array)$request->getParameters();
+
         $props = [
             'url' => $url,
-            'post' => (array)$request->getParameters(),
+            'post' => $content,
             'files' => (array)$request->getFiles(),
             'cookies' => (array)$request->getCookies(),
             'session' => $this->getSession(),


### PR DESCRIPTION
Currently if we specify Content-Type application/json for example:
```
$I->haveHttpHeader('Content-Type', 'application/json');
```
It creates new Request with content here:
```
$this->internalRequest = new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
```
Where $paremeters is empty and $content with json, so we need to handle this I guess