### PR TITLE
Updated .travis config for php 5.6 and 7.4 and cakephp/app 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,32 @@
 language: php
 
-sudo: false
+dist: xenial
+
+services:
+  - mysql
 
 php:
   - 5.6
-  - 7.0
-  - 7.1
+  - 7.4
 
 env:
   matrix:
-    - CAKE_VERSION=3.4.*
-    - CAKE_VERSION=3.5.*
+    - CAKE_VERSION=^3.8 REINSTALL_CAKEPHP=0
+    - CAKE_VERSION=^3.8 REINSTALL_CAKEPHP=1
   global:
-    - REINSTALL_CAKEPHP=0
     - DEFAULT=1
     - DB=mysql
-    - db_dsn='mysql://travis:travis@0.0.0.0/cakephp_test'
+    - db_dsn='mysql://travis:travis@127.0.0.1/cakephp_test'
 
 cache:
   directories:
-    - vendor
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 matrix:
   fast_finish: true
 
   include:
-  - php: 5.4
-    env: CAKE_VERSION=3.1.* REINSTALL_CAKEPHP=1
-  - php: 5.5
-    env: CAKE_VERSION=3.2.* REINSTALL_CAKEPHP=1
-  - php: 5.5
-    env: CAKE_VERSION=3.3.*
-  - php: 7.1
+  - php: 7.4
     env: PHPCS=1 DEFAULT=0
 
 before_install:
@@ -51,14 +45,14 @@ install:
   - if [ $DEFAULT = '1' ]; then composer run-script --no-interaction post-install-cmd; fi
   - if [ $DEFAULT = '1' ]; then cd ../sample_app; fi
   - if [ $DEFAULT = '1' ]; then cp -rv ../test_app/src ./ && cp -r ../test_app/config ./ && cp -r ../test_app/webroot ./; fi
-  - if [ $CAKE_VERSION = '3.1.*' ]; then mv config/app-3.1.php config/app.php ; fi
+  - if [ $CAKE_VERSION = '3.1.*' ]; then mv config/app-3.1.php config/app.php; fi
   - if [ $DEFAULT = '1' ]; then cp ../test_app/src/Console/Installer.php src/Console/.; fi
   - if [ $DEFAULT = '1' ]; then cp ../test_app/composer.json .; fi
   - if [ $DEFAULT = '1' ]; then composer install --no-interaction; fi
 
 before_script:
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test;'; fi
-  - if [ $DB = 'mysql' ]; then echo "USE mysql;\nUPDATE user SET password=PASSWORD('travis') WHERE user='travis';\nFLUSH PRIVILEGES;\n" | mysql -u root; fi
+  - if [ $DB = 'mysql' ]; then echo "ALTER USER 'travis'@'localhost' IDENTIFIED BY 'travis';\nFLUSH PRIVILEGES;\n" | mysql -u root; fi
   - if [ $PHPCS = '1' ]; then composer require --dev squizlabs/php_codesniffer; fi
   - if [ $DEFAULT = '1' ]; then cd $TRAVIS_BUILD_DIR/tests/test_app; fi
   - if [ $DEFAULT = '1' ]; then vendor/bin/codecept bootstrap; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ php:
 
 env:
   matrix:
-    - CAKE_VERSION=^3.8 REINSTALL_CAKEPHP=0
-    - CAKE_VERSION=^3.8 REINSTALL_CAKEPHP=1
+    - CAKE_VERSION=^3.6.0 REINSTALL_CAKEPHP=0
   global:
     - DEFAULT=1
     - DB=mysql
@@ -20,14 +19,16 @@ env:
 
 cache:
   directories:
-    - $HOME/.composer/cache/files
+    - $HOME/.composer/files
 
 matrix:
   fast_finish: true
 
   include:
-  - php: 7.4
-    env: PHPCS=1 DEFAULT=0
+    - php: 5.6
+      env: CAKE_VERSION='~3.6.0' REINSTALL_CAKEPHP=1
+    - php: 7.4
+      env: PHPCS=1 DEFAULT=0
 
 before_install:
   - phpenv config-rm xdebug.ini
@@ -37,9 +38,9 @@ before_install:
 
 install:
   - composer install --prefer-dist --no-interaction
-  - if [ ! -z ${CAKE_VERSION} ]; then composer create-project --no-interaction cakephp/app:$CAKE_VERSION tests/test_app; fi
+  - if [ $DEFAULT = '1' ]; then composer create-project --no-interaction cakephp/app:$CAKE_VERSION tests/test_app; fi
   - if [ $DEFAULT = '1' ]; then cd tests/test_app; fi
-  - if [ $REINSTALL_CAKEPHP -eq 1 ]; then rm composer.lock && rm -rf vendor/ && composer require cakephp/cakephp:$CAKE_VERSION ; fi
+  - if [ $REINSTALL_CAKEPHP -eq 1 ]; then rm composer.lock && rm -rf vendor/ && composer require cakephp/cakephp:$CAKE_VERSION; fi
   - if [ $DEFAULT = '1' ]; then composer config repositories.cakephp/codeception vcs ../../; fi
   - if [ $DEFAULT = '1' ]; then composer require --prefer-source --dev cakephp/codeception:dev-ci-build#$TRAVIS_COMMIT; fi
   - if [ $DEFAULT = '1' ]; then composer run-script --no-interaction post-install-cmd; fi

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
   stopOnFailure="false"
   syntaxCheck="false"
   bootstrap="tests/bootstrap.php"
+  strict="true"
 >
   <php>
     <ini name="memory_limit" value="-1"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
   colors="true"
-  processIsolation="false"
-  stopOnFailure="false"
-  syntaxCheck="false"
   bootstrap="tests/bootstrap.php"
-  strict="true"
 >
+    
   <php>
     <ini name="memory_limit" value="-1"/>
   </php>

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -177,7 +177,7 @@ class Connector extends Client
      */
     public function controllerSpy(Event $event)
     {
-        if (empty($event->getData('controller'))) {
+        if (!$event->getData('controller')) {
             return;
         }
 

--- a/src/Helper/DbTrait.php
+++ b/src/Helper/DbTrait.php
@@ -42,7 +42,7 @@ trait DbTrait
     protected function deleteAllRecords($model, $data)
     {
         $table = TableRegistry::get($model);
-        $table->connection()
+        $table->getConnection()
             ->disableConstraints(function () use ($table, $data) {
                 $table->deleteAll($data);
             });
@@ -71,8 +71,8 @@ trait DbTrait
             $this->insertedRecords[$model] = [];
         }
 
-        $this->insertedRecords[$model][$table->primaryKey() . ' IN'][] = $data->{$table->primaryKey()};
-        return $data->{$table->primaryKey()};
+        $this->insertedRecords[$model][$table->getPrimaryKey() . ' IN'][] = $data->{$table->getPrimaryKey()};
+        return $data->{$table->getPrimaryKey()};
     }
 
     /**

--- a/src/Helper/DbTrait.php
+++ b/src/Helper/DbTrait.php
@@ -2,6 +2,7 @@
 namespace Cake\Codeception\Helper;
 
 use Cake\ORM\TableRegistry;
+use \RuntimeException;
 
 trait DbTrait
 {
@@ -71,8 +72,13 @@ trait DbTrait
             $this->insertedRecords[$model] = [];
         }
 
-        $this->insertedRecords[$model][$table->getPrimaryKey() . ' IN'][] = $data->{$table->getPrimaryKey()};
-        return $data->{$table->getPrimaryKey()};
+        $primaryKey = $table->getPrimaryKey();
+        if (is_array($primaryKey)) {
+            throw new RuntimeException('Expected single primary key for table - ' . $model);
+        }
+
+        $this->insertedRecords[$model][$primaryKey . ' IN'][] = $data->{$primaryKey};
+        return $data->{$primaryKey};
     }
 
     /**

--- a/tests/Fixture/composer.json
+++ b/tests/Fixture/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.16",
-        "cakephp/cakephp": "~3.0",
+        "php": ">=5.6",
+        "cakephp/cakephp": "^3.4",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
         "cakephp/plugin-installer": "*"

--- a/tests/Fixture/composer.json
+++ b/tests/Fixture/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "cakephp/cakephp": "^3.4",
+        "cakephp/cakephp": "^3.6",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
         "cakephp/plugin-installer": "*"

--- a/tests/sample_app/codeception.yml
+++ b/tests/sample_app/codeception.yml
@@ -16,7 +16,7 @@ extensions:
 modules:
     config:
         Db:
-           dsn: 'mysql:host=0.0.0.0;dbname=cakephp_test'
+           dsn: 'mysql:host=127.0.0.1;dbname=cakephp_test'
            user: 'travis'
            password: 'travis'
            populate: true

--- a/tests/sample_app/tests/Functional/LoadFixturesCept.php
+++ b/tests/sample_app/tests/Functional/LoadFixturesCept.php
@@ -6,7 +6,7 @@ $I = new FunctionalTester($scenario);
 
 $I->wantTo('load fixtures');
 
-$I->useFixtures(['core.authors', 'core.posts']);
+$I->useFixtures(['core.Authors', 'core.Posts']);
 $I->loadFixtures('Authors');
 $I->seeInDatabase('authors', ['id' => 1, 'name' => 'mariano']);
 
@@ -15,5 +15,5 @@ $I->seeInDatabase('posts', ['author_id' => 1, 'title' => 'First Post']);
 
 // useFixtures use only once
 $I->expectException('\Codeception\Exception\ModuleException', function () use ($I) {
-    $I->useFixtures('core.tags');
+    $I->useFixtures('core.Tags');
 });

--- a/tests/sample_app/tests/Functional/LoadFixturesCest.php
+++ b/tests/sample_app/tests/Functional/LoadFixturesCest.php
@@ -12,8 +12,8 @@ class LoadFixturesCest
 
     public $autoFixtures = false;
     public $fixtures = [
-        'core.authors',
-        'core.posts',
+        'core.Authors',
+        'core.Posts',
     ];
 
     /**


### PR DESCRIPTION
I'm not sure how the original tests were passing when the app config was copied only for version 3.1.

This has a number of php notices in phpunit tests and deprecation warnings.