### PR TITLE
Improve assertions about file/directory assertions

### DIFF
--- a/tests/TestCase/Command/BootstrapTest.php
+++ b/tests/TestCase/Command/BootstrapTest.php
@@ -9,7 +9,7 @@ class BootstrapTest extends TestCase
     public function testHelpersCreatedInTestSuite()
     {
         $testSuiteDir = TEST_APP_ROOT . 'src' . DS . 'TestSuite' . DS . 'Codeception' . DS;
-        $this->assertTrue(is_dir($testSuiteDir), 'src/TestSuite/Codeception directory must be auto-created');
+        $this->assertDirectoryExists($testSuiteDir, 'src/TestSuite/Codeception directory must be auto-created');
 
         $this->assertFileExists($testSuiteDir . 'Helper/Acceptance.php', 'AcceptanceHelper must be auto-created');
         $this->assertFileExists($testSuiteDir . 'Helper/Functional.php', 'FunctionalHelper must be auto-created');
@@ -29,22 +29,22 @@ class BootstrapTest extends TestCase
         $testsDir = TEST_APP_ROOT . 'tests' . DS;
 
         $acceptanceDir = $testsDir . 'Acceptance' . DS;
-        $this->assertTrue(is_dir($acceptanceDir), 'Acceptance test suite directory must be auto-created');
+        $this->assertDirectoryExists($acceptanceDir, 'Acceptance test suite directory must be auto-created');
         $this->assertFileExists($acceptanceDir . 'bootstrap.php', 'Acceptance bootstrap.php must be auto-created');
-        
+
         $functionalDir = $testsDir . 'Functional' . DS;
-        $this->assertTrue(is_dir($functionalDir), 'Functional test suite directory must be auto-created');
+        $this->assertDirectoryExists($functionalDir, 'Functional test suite directory must be auto-created');
         $this->assertFileExists($functionalDir . 'bootstrap.php', 'Functional bootstrap.php must be auto-created');
 
         $unitDir = $testsDir . 'Unit' . DS;
-        $this->assertTrue(is_dir($unitDir), 'Unit test suite directory must be auto-created');
+        $this->assertDirectoryExists($unitDir, 'Unit test suite directory must be auto-created');
         $this->assertFileExists($unitDir . 'bootstrap.php', 'Unit bootstrap.php must be auto-created');
     }
 
     public function testCoreConfigurationFileCreated()
     {
         $configFilePath = TEST_APP_ROOT . 'codeception.yml';
-        $this->assertTrue(file_exists($configFilePath), 'File `codeception.yml` must be auto-created');
+        $this->assertFileExists($configFilePath, 'File `codeception.yml` must be auto-created');
 
         $result = file_get_contents($configFilePath);
         $this->assertNotContains('dsn', $result, 'No dsn configuration should be included');
@@ -55,7 +55,7 @@ class BootstrapTest extends TestCase
     public function testAcceptanceConfigurationFileCreated()
     {
         $configFilePath = TEST_APP_ROOT . 'tests' . DS . 'Acceptance.suite.yml';
-        $this->assertTrue(file_exists($configFilePath), 'File `acceptance.suite.yml` must be auto-created');
+        $this->assertFileExists($configFilePath, 'File `acceptance.suite.yml` must be auto-created');
 
         $result = file_get_contents($configFilePath);
         $this->assertContains('namespace: App\TestSuite\Codeception', $result, 'namespace must be enabled');
@@ -69,7 +69,7 @@ class BootstrapTest extends TestCase
     public function testFunctionalConfigurationFileCreated()
     {
         $configFilePath = TEST_APP_ROOT . 'tests' . DS . 'Functional.suite.yml';
-        $this->assertTrue(file_exists($configFilePath), 'File `functional.suite.yml` must be auto-created');
+        $this->assertFileExists($configFilePath, 'File `functional.suite.yml` must be auto-created');
 
         $result = file_get_contents($configFilePath);
         $this->assertContains('namespace: App\TestSuite\Codeception', $result, 'namespace must be enabled');
@@ -83,7 +83,7 @@ class BootstrapTest extends TestCase
     public function testUnitConfigurationFileCreated()
     {
         $configFilePath = TEST_APP_ROOT . 'tests' . DS . 'Unit.suite.yml';
-        $this->assertTrue(file_exists($configFilePath), 'File `unit.suite.yml` must be auto-created');
+        $this->assertFileExists($configFilePath, 'File `unit.suite.yml` must be auto-created');
 
         $result = file_get_contents($configFilePath);
         $this->assertContains('namespace: App\TestSuite\Codeception', $result, 'namespace must be enabled');

--- a/tests/TestCase/Command/GenerateCeptTest.php
+++ b/tests/TestCase/Command/GenerateCeptTest.php
@@ -8,7 +8,7 @@ class GenerateCeptTest extends TestCase
     public function testExecute()
     {
         $file = TEST_APP_ROOT . 'tests' . DS . 'Functional' . DS . 'FooCept.php';
-        $this->assertTrue(file_exists($file), "Cest file [$file] should be generated");
+        $this->assertFileExists($file, "Cest file [$file] should be generated");
     }
 
     public function testGeneratorProduce()

--- a/tests/TestCase/Command/GenerateSuiteTest.php
+++ b/tests/TestCase/Command/GenerateSuiteTest.php
@@ -10,22 +10,22 @@ class GenerateSuiteTest extends TestCase
     {
         $testSuiteDir = TEST_APP_ROOT . 'src' . DS . 'TestSuite' . DS . 'Codeception' . DS;
 
-        $this->assertTrue(file_exists($testSuiteDir . 'Helper/Api.php'), 'Api helper must be auto-created');
-        $this->assertTrue(file_exists($testSuiteDir . 'ApiTester.php'), 'ApiTester must be auto-generated');
+        $this->assertFileExists($testSuiteDir . 'Helper/Api.php', 'Api helper must be auto-created');
+        $this->assertFileExists($testSuiteDir . 'ApiTester.php', 'ApiTester must be auto-generated');
     }
 
     public function testSuitesCreatedInTests()
     {
         $testsDir = TEST_APP_ROOT . 'tests' . DS . 'Api' . DS;
 
-        $this->assertTrue(is_dir($testsDir), 'Api test suite directory must be auto-created');
+        $this->assertDirectoryExists($testsDir, 'Api test suite directory must be auto-created');
         $this->assertFileExists($testsDir . 'bootstrap.php', 'Api bootstrap.php must be auto-created');
     }
 
     public function testApiConfigurationFileCreated()
     {
         $configFilePath = TEST_APP_ROOT . 'tests' . DS . 'Api.suite.yml';
-        $this->assertTrue(file_exists($configFilePath), 'File `Api.suite.yml` must be auto-created');
+        $this->assertFileExists($configFilePath, 'File `Api.suite.yml` must be auto-created');
 
         $result = file_get_contents($configFilePath);
         $this->assertContains('namespace: App\TestSuite\Codeception', $result, 'namespace must be enabled');


### PR DESCRIPTION
# Changed log

- Using `assertDirectoryExists` to assert specific directory is existed.
- Using `assertFileExists` to assert specific file is existed.